### PR TITLE
Add user targeting to `info` and `compat` commands

### DIFF
--- a/AugmentsBot.py
+++ b/AugmentsBot.py
@@ -29,18 +29,22 @@ async def on_message(message):
     #print(f'Message from {message.author}: {message.content}')
 
 @client.hybrid_command(name="info")
-async def cmd_info(ctx :commands.Context, mod_id :str, keyword :str, version_filter :str = '%'):
+async def cmd_info(ctx :commands.Context, mod_id :str, keyword :str, version_filter :str = '%', target_user :discord.Member = None):
+    msg :str = target_user.mention if target_user is not None else None
     for response in Database.get_info_formatted(modID=mod_id, keyword=keyword, filter=version_filter):
         if not response.description:
             #Catches "This keyword has no associated documentation" messages
             await ctx.send(embed=response, ephemeral=True)
             return
-        await ctx.send(embed=response)
+        await ctx.send(content=msg, embed=response)
+        msg = None
 
 @client.hybrid_command(name="compat")
-async def cmd_compat(ctx :commands.Context, mod_a :str, mod_b :str, version_filter :str = '%'):
+async def cmd_compat(ctx :commands.Context, mod_a :str, mod_b :str, version_filter :str = '%', target_user :discord.Member = None):
+    msg :str = target_user.mention if target_user is not None else None
     for response in Database.get_compat_formatted(mod_a=mod_a,mod_b=mod_b,filter=version_filter):
-        await ctx.send(embed=response)
+        await ctx.send(content=msg, embed=response)
+        msg = None
 
 @client.hybrid_command(name='add_info')
 @commands.has_guild_permissions(manage_messages=True)


### PR DESCRIPTION
Allows you to ping a specific user when sending bot info calls.