### PR TITLE
Preview and Publish

### DIFF
--- a/AugmentsBot.py
+++ b/AugmentsBot.py
@@ -19,7 +19,10 @@ class Publish(discord.ui.View):
     async def publish_click_interaction(self, interaction: discord.Interaction, button: discord.ui.Button):
         self.clear_items()  # Remove all elements from the View
         await interaction.response.edit_message(embeds=interaction.message.embeds, content=interaction.message.content, view=self)  # Update the triggering message
-        await interaction.followup.send(embeds=interaction.message.embeds, content=interaction.message.content)  # Send new message
+        embeds = interaction.message.embeds
+        if embeds:
+            embeds[0].add_field(name="From", value=interaction.user.mention)
+        await interaction.followup.send(embeds=embeds, content=interaction.message.content)  # Send new message
 
 @client.event
 async def on_ready():

--- a/AugmentsBot.py
+++ b/AugmentsBot.py
@@ -2,6 +2,7 @@ import discord
 from discord.ext import commands
 import Database
 import Modals
+import Views
 
 tokenFile = open("token.txt", 'r')
 token = tokenFile.readline()
@@ -13,16 +14,6 @@ intents.typing = True
 intents.messages = True
 
 client = commands.Bot(command_prefix='/', intents=intents)
-
-class Publish(discord.ui.View):
-    @discord.ui.button(label='Publish', style=discord.ButtonStyle.gray)
-    async def publish_click_interaction(self, interaction: discord.Interaction, button: discord.ui.Button):
-        self.clear_items()  # Remove all elements from the View
-        await interaction.response.edit_message(embeds=interaction.message.embeds, content=interaction.message.content, view=self)  # Update the triggering message
-        embeds = interaction.message.embeds
-        if embeds:
-            embeds[0].add_field(name="From", value=interaction.user.mention)
-        await interaction.followup.send(embeds=embeds, content=interaction.message.content)  # Send new message
 
 @client.event
 async def on_ready():
@@ -47,7 +38,7 @@ async def cmd_info(ctx :commands.Context, mod_id :str, keyword :str, version_fil
             await ctx.send(embed=response, ephemeral=True)
             return
         if preview:
-            view = Publish()  # Make a new view (that contains a Publish button)
+            view = Views.Publish()  # Make a new view (that contains a Publish button)
             await ctx.send(content=msg, embed=response, ephemeral=True, view=view)
         else:
             await ctx.send(content=msg, embed=response)
@@ -58,7 +49,7 @@ async def cmd_compat(ctx :commands.Context, mod_a :str, mod_b :str, version_filt
     msg :str = target_user.mention if target_user is not None else None
     for response in Database.get_compat_formatted(mod_a=mod_a,mod_b=mod_b,filter=version_filter):
         if preview:
-            view = Publish()  # Make a new view (that contains a Publish button)
+            view = Views.Publish()  # Make a new view (that contains a Publish button)
             await ctx.send(content=msg, embed=response, ephemeral=True, view=view)
         else:
             await ctx.send(content=msg, embed=response)

--- a/AugmentsBot.py
+++ b/AugmentsBot.py
@@ -29,21 +29,21 @@ async def on_message(message):
     #print(f'Message from {message.author}: {message.content}')
 
 @client.hybrid_command(name="info")
-async def cmd_info(ctx :commands.Context, mod_id :str, keyword :str, version_filter :str = '%', target_user :discord.Member = None):
+async def cmd_info(ctx :commands.Context, mod_id :str, keyword :str, version_filter :str = '%', target_user :discord.Member = None, private: bool = False):
     msg :str = target_user.mention if target_user is not None else None
     for response in Database.get_info_formatted(modID=mod_id, keyword=keyword, filter=version_filter):
         if not response.description:
             #Catches "This keyword has no associated documentation" messages
             await ctx.send(embed=response, ephemeral=True)
             return
-        await ctx.send(content=msg, embed=response)
+        await ctx.send(content=msg, embed=response, ephemeral=private)
         msg = None
 
 @client.hybrid_command(name="compat")
-async def cmd_compat(ctx :commands.Context, mod_a :str, mod_b :str, version_filter :str = '%', target_user :discord.Member = None):
+async def cmd_compat(ctx :commands.Context, mod_a :str, mod_b :str, version_filter :str = '%', target_user :discord.Member = None, private: bool = False):
     msg :str = target_user.mention if target_user is not None else None
     for response in Database.get_compat_formatted(mod_a=mod_a,mod_b=mod_b,filter=version_filter):
-        await ctx.send(content=msg, embed=response)
+        await ctx.send(content=msg, embed=response, ephemeral=private)
         msg = None
 
 @client.hybrid_command(name='add_info')

--- a/Views.py
+++ b/Views.py
@@ -1,0 +1,11 @@
+import discord
+
+class Publish(discord.ui.View):
+    @discord.ui.button(label='Publish', style=discord.ButtonStyle.gray)
+    async def publish_click_interaction(self, interaction: discord.Interaction, button: discord.ui.Button):
+        self.clear_items()  # Remove all elements from the View
+        await interaction.response.edit_message(embeds=interaction.message.embeds, content=interaction.message.content, view=self)  # Update the triggering message
+        embeds = interaction.message.embeds
+        if embeds:
+            embeds[0].add_field(name="From", value=interaction.user.mention)
+        await interaction.followup.send(embeds=embeds, content=interaction.message.content)  # Send new message


### PR DESCRIPTION
This adds an optional boolean flag to /info and /compat messages so that they will show all their entries ephemerally instead of posted to channel.

Such ephemeral messages will get a "Publish" button added to them that, if clicked, will post a clone of that ephemeral message.