### PR TITLE
Ghtoken missing error handling

### DIFF
--- a/AugmentsBot.py
+++ b/AugmentsBot.py
@@ -1,5 +1,6 @@
 import discord
 from discord.ext import commands
+import os
 import Database
 import Modals
 
@@ -58,6 +59,9 @@ async def cmd_add_compat(ctx :commands.Context):
 
 @client.hybrid_command(name="bug_report")
 async def cmd_issue(ctx :commands.Context, mod_id :str):
+    if not os.path.exists("ghtoken.txt"):
+        return await ctx.interaction.response.send_message("This mod is not configured for bug reporting", ephemeral=True)
+
     switch={
         "pmmo":"Project-MMO-2.0",
         "bot": "AugmentsBot"
@@ -66,7 +70,7 @@ async def cmd_issue(ctx :commands.Context, mod_id :str):
 
     await (ctx.interaction.response.send_modal(Modals.IssueModal(projectID=projectID)) \
         if projectID != None \
-        else ctx.interaction.response.send_message("This mod is not configured for bug reporting", ephemeral=True))
+        else await ctx.interaction.response.send_message("This mod is not configured for bug reporting", ephemeral=True))
 
 @client.hybrid_command(name="info_keywords")
 async def cmd_list(ctx :commands.Context, mod_id :str, filter :str = "%"):

--- a/AugmentsBot.py
+++ b/AugmentsBot.py
@@ -70,7 +70,7 @@ async def cmd_issue(ctx :commands.Context, mod_id :str):
 
     await (ctx.interaction.response.send_modal(Modals.IssueModal(projectID=projectID)) \
         if projectID != None \
-        else await ctx.interaction.response.send_message("This mod is not configured for bug reporting", ephemeral=True))
+        else ctx.interaction.response.send_message("This mod is not configured for bug reporting", ephemeral=True))
 
 @client.hybrid_command(name="info_keywords")
 async def cmd_list(ctx :commands.Context, mod_id :str, filter :str = "%"):

--- a/GitHub.py
+++ b/GitHub.py
@@ -1,12 +1,15 @@
 import requests
 import json
 
-tokenFile = open("ghtoken.txt", 'r')
-token = tokenFile.readline()
-tokenFile.close()
+try:
+    tokenFile = open("ghtoken.txt", 'r')
+    token = tokenFile.readline()
+    tokenFile.close()
 
-headers = {"Authorization" : f"Bearer {token}",
-    "Accept": "application/vnd.github+json"}
+    headers = {"Authorization" : f"Bearer {token}",
+        "Accept": "application/vnd.github+json"}
+except FileNotFoundError:
+    print("ghtoken.txt not found!")
 
 def createIssue(Repositoryname : str, title :str, body :str):
     data = {"title": title, "body": body}


### PR DESCRIPTION
Sick of having to comment out when I'm in dev. This should now be handled gracefully.
A line gets printed at bot start to state that the file is missing, and user gets notified when they initiate the command.

GitHub.py: edited to handle missing file errors.
AugmentsBot.py: edited to check if the file is missing and immediately notify user before they try to enter a bunch of details.